### PR TITLE
Andino Firmware for esp32 and micro-ros

### DIFF
--- a/andino_firmware_esp32/.clang-format
+++ b/andino_firmware_esp32/.clang-format
@@ -1,0 +1,38 @@
+# This file determines clang-format's style settings; for details, refer to
+# http://clang.llvm.org/docs/ClangFormatStyleOptions.html
+
+BasedOnStyle:  Google
+ColumnLimit: 100
+
+DerivePointerAlignment: false
+PointerAlignment: Left
+
+AlignConsecutiveMacros: true
+
+# Specify the #include statement order.  This implements the order mandated by
+# the Google C++ Style Guide: related header, C headers, C++ headers, library
+# headers, and finally the project headers.
+#
+# To obtain updated lists of system headers used in the below expressions, see:
+# http://stackoverflow.com/questions/2027991/list-of-standard-header-files-in-c-and-c/2029106#2029106.
+IncludeCategories:
+  - Regex:    '^<clang-format-priority-15>$'
+    Priority: 15
+  - Regex:    '^<clang-format-priority-25>$'
+    Priority: 25
+  - Regex:    '^<clang-format-priority-35>$'
+    Priority: 35
+  - Regex:    '^<clang-format-priority-45>$'
+    Priority: 45
+  # C system headers.
+  - Regex:    '^[<"](aio|arpa/inet|assert|complex|cpio|ctype|curses|dirent|dlfcn|errno|fcntl|fenv|float|fmtmsg|fnmatch|ftw|glob|grp|iconv|inttypes|iso646|langinfo|libgen|limits|locale|math|monetary|mqueue|ndbm|netdb|net/if|netinet/in|netinet/tcp|nl_types|poll|pthread|pwd|regex|sched|search|semaphore|setjmp|signal|spawn|stdalign|stdarg|stdatomic|stdbool|stddef|stdint|stdio|stdlib|stdnoreturn|string|strings|stropts|sys/ipc|syslog|sys/mman|sys/msg|sys/resource|sys/select|sys/sem|sys/shm|sys/socket|sys/stat|sys/statvfs|sys/time|sys/times|sys/types|sys/uio|sys/un|sys/utsname|sys/wait|tar|term|termios|tgmath|threads|time|trace|uchar|ulimit|uncntrl|unistd|utime|utmpx|wchar|wctype|wordexp)\.h[">]$'
+    Priority: 20
+  # C++ system headers (as of C++17).
+  - Regex:    '^[<"](algorithm|array|atomic|bitset|cassert|ccomplex|cctype|cerrno|cfenv|cfloat|chrono|cinttypes|ciso646|climits|clocale|cmath|codecvt|complex|condition_variable|csetjmp|csignal|cstdalign|cstdarg|cstdbool|cstddef|cstdint|cstdio|cstdlib|cstring|ctgmath|ctime|cuchar|cwchar|cwctype|deque|exception|forward_list|fstream|functional|future|initializer_list|iomanip|ios|iosfwd|iostream|istream|iterator|limits|list|locale|map|memory|mutex|new|numeric|optional|ostream|queue|random|ratio|regex|scoped_allocator|set|shared_mutex|sstream|stack|stdexcept|streambuf|string|strstream|system_error|thread|tuple|type_traits|typeindex|typeinfo|unordered_map|unordered_set|utility|valarray|variant|vector)[">]$'
+    Priority: 30
+  # Other libraries' h files (with angles).
+  - Regex:    '^<'
+    Priority: 40
+  # Other libraries' h files (with quotes).
+  - Regex:    '^"'
+    Priority: 41

--- a/andino_firmware_esp32/CMakeLists.txt
+++ b/andino_firmware_esp32/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.8)
+project(andino_firmware_esp32)
+
+find_package(ament_cmake REQUIRED)
+
+install(
+  FILES
+    andino_firmware_esp32.ino
+    platformio.ini
+  DESTINATION
+    share/${PROJECT_NAME}/
+)
+
+install(
+  DIRECTORY
+    src
+  DESTINATION
+    share/${PROJECT_NAME}/
+)
+
+ament_package()

--- a/andino_firmware_esp32/andino_firmware_esp32.ino
+++ b/andino_firmware_esp32/andino_firmware_esp32.ino
@@ -1,0 +1,4 @@
+/*
+ * Arduino IDE sketch file. This file is required to be able to compile and
+ * upload the Andino firmware using Arduino IDE.
+ */

--- a/andino_firmware_esp32/package.xml
+++ b/andino_firmware_esp32/package.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>andino_firmware_esp32</name>
+  <version>0.2.0</version>
+  <description>The andino_firmware package</description>
+  <maintainer email="franco.c@ekumenlabs.com">Franco Cipollone</maintainer>
+  <maintainer email="gabriel.diaz@ekumenlabs.com">Gabriel Diaz</maintainer>
+  <license file="LICENSE">BSD Clause 3</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/andino_firmware_esp32/platformio.ini
+++ b/andino_firmware_esp32/platformio.ini
@@ -1,0 +1,25 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+[platformio]
+default_envs =az-delivery-devkit-v4
+
+; Base configuration for Atmel AVR based Arduino boards.
+[base_esp32]
+platform = espressif32
+framework = arduino
+monitor_speed = 57600
+lib_deps =
+ https://github.com/micro-ROS/micro_ros_platformio
+board_microros_distro = humble
+board_microros_transport = serial
+
+[env:az-delivery-devkit-v4]
+extends = base_esp32
+board = az-delivery-devkit-v4

--- a/andino_firmware_esp32/src/constants.h
+++ b/andino_firmware_esp32/src/constants.h
@@ -1,0 +1,57 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2024, Ekumen Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+namespace andino {
+
+/// @brief Common constants.
+struct Constants {
+  /// @brief Minimum PWM wave duty cycle (0%) (see
+  /// https://www.arduino.cc/reference/en/language/functions/analog-io/analogwrite/).
+  static constexpr int kPwmMin{0};
+  /// @brief Maximum PWM wave duty cycle (100%) (see
+  /// https://www.arduino.cc/reference/en/language/functions/analog-io/analogwrite/).
+  static constexpr int kPwmMax{255};
+
+  /// @brief PID computation rate [Hz].
+  static constexpr int kPidRate{30};
+  /// @brief PID default tuning proportional gain.
+  static constexpr int kPidKp{30};
+  /// @brief PID default tuning derivative gain.
+  static constexpr int kPidKd{10};
+  /// @brief PID default tuning integral gain.
+  static constexpr int kPidKi{0};
+  /// @brief PID default tuning output gain.
+  static constexpr int kPidKo{10};
+};
+
+}  // namespace andino

--- a/andino_firmware_esp32/src/encoder_driver.cpp
+++ b/andino_firmware_esp32/src/encoder_driver.cpp
@@ -1,0 +1,75 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2024, Ekumen Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#include "encoder_driver.h"
+
+namespace andino {
+
+EncoderDriver::EncoderDriver(const int& encoder_channel_a, const int& encoder_channel_b)
+    : encoder_channel_a_{encoder_channel_a}, encoder_channel_b_{encoder_channel_b} {}
+
+void EncoderDriver::begin() {
+  pinMode(encoder_channel_a_, INPUT);
+  pinMode(encoder_channel_b_, INPUT);
+}
+
+void IRAM_ATTR EncoderDriver::callback() {
+  previous_state_ = current_state_;
+
+  if (digitalRead(encoder_channel_a_))
+    bitSet(current_state_, 1);
+  else
+    bitClear(current_state_, 1);
+
+  if (digitalRead(encoder_channel_b_))
+    bitSet(current_state_, 0);
+  else
+    bitClear(current_state_, 0);
+
+  if (previous_state_ == 2 && current_state_ == 0) instance_count_--;
+  if (previous_state_ == 0 && current_state_ == 1) instance_count_--;
+  if (previous_state_ == 3 && current_state_ == 2) instance_count_--;
+  if (previous_state_ == 1 && current_state_ == 3) instance_count_--;
+
+  if (previous_state_ == 1 && current_state_ == 0) instance_count_++;
+  if (previous_state_ == 3 && current_state_ == 1) instance_count_++;
+  if (previous_state_ == 0 && current_state_ == 2) instance_count_++;
+  if (previous_state_ == 2 && current_state_ == 3) instance_count_++;
+}
+
+int EncoderDriver::read() {
+  int instance_count = 0;
+  noInterrupts();
+  instance_count = instance_count_;
+  interrupts();
+  return instance_count;
+}
+}  // namespace andino

--- a/andino_firmware_esp32/src/encoder_driver.h
+++ b/andino_firmware_esp32/src/encoder_driver.h
@@ -1,0 +1,73 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2024, Ekumen Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+#include <Arduino.h>
+
+namespace andino {
+
+/// @brief This class allows to use a quadrature encoder by configuring it and
+/// then getting its ticks count value.
+class EncoderDriver {
+ public:
+  /// @brief Constructs a new Encoder object.
+  ///
+  /// @param encoder_channel_a Digital interrupt input connected to encoder
+  /// channel A pin.
+  /// @param encoder_channel_b Digital interrupt input connected to encoder
+  /// channel B pin.
+  EncoderDriver(const int& encoder_channel_a, const int& encoder_channel_b);
+
+  /// @brief Initializes the encoder.
+  void begin();
+
+  /// @brief Channels interrupt callback.
+  void IRAM_ATTR callback();
+
+  /// @brief Gets the ticks count value.
+  ///
+  /// @return Ticks count value.
+  int read();
+
+ private:
+  /// Digital interrupt input connected to encoder channel A pin.
+  int encoder_channel_a_{0};
+  /// Digital interrupt input connected to encoder channel B pin.
+  int encoder_channel_b_{0};
+  /// Number of constructed Encoder instances.
+  volatile int instance_count_{0};
+
+  /// Previous State of channel A and channel B encoder.
+  volatile byte previous_state_{0};
+  /// Current State of channel A and channel B encoder.
+  volatile byte current_state_{0};
+};
+}  // namespace andino

--- a/andino_firmware_esp32/src/hw.h
+++ b/andino_firmware_esp32/src/hw.h
@@ -1,0 +1,63 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2024, Ekumen Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+namespace andino {
+
+struct Hw {
+  /// @brief Left encoder channel A pin. Connected to 15 (GPIO 15).
+  static const unsigned int kLeftEncoderChannelAGpioPin{15};
+  /// @brief Left encoder channel B pin. Connected to 2 (GPIO 2).
+  static const unsigned int kLeftEncoderChannelBGpioPin{2};
+
+  /// @brief Right encoder channel A pin. Connected to 12 (GPIO 12).
+  static const unsigned int kRightEncoderChannelAGpioPin{12};
+  /// @brief Right encoder channel B pin. Connected to 14 (GPIO 14).
+  static const unsigned int kRightEncoderChannelBGpioPin{14};
+
+  /// @brief Left motor driver backward pin. Connected to 19 (GPIO 19).
+  static const unsigned int kLeftMotorBackwardGpioPin{19};
+  /// @brief Left motor driver forward pin. Connected to 18 (GPIO 18).
+  static const unsigned int kLeftMotorForwardGpioPin{18};
+
+  /// @brief Right motor driver backward pin. Connected to 22 (GPIO 22).
+  static const unsigned int kRightMotorBackwardGpioPin{22};
+  /// @brief Right motor driver forward pin. Connected to 23 (GPIO 23).
+  static const unsigned int kRightMotorForwardGpioPin{23};
+
+  /// @brief Left motor driver enable pin. Connected to 32 (GPIO 32).
+  static const unsigned int kLeftMotorEnableGpioPin{32};
+  /// @brief Right motor driver enable pin. Connected to 33 (GPIO 33).
+  static const unsigned int kRightMotorEnableGpioPin{33};
+};
+
+}  // namespace andino

--- a/andino_firmware_esp32/src/main.cpp
+++ b/andino_firmware_esp32/src/main.cpp
@@ -1,0 +1,218 @@
+#include <Arduino.h>
+#include <micro_ros_platformio.h>
+#include <rcl/rcl.h>
+#include <rclc/executor.h>
+#include <rclc/rclc.h>
+#include <std_msgs/msg/int64.h>
+#include <std_msgs/msg/int64_multi_array.h>
+#include <std_msgs/msg/multi_array_dimension.h>
+
+#include "constants.h"
+#include "encoder_driver.h"
+#include "hw.h"
+#include "motor_driver.h"
+#include "pid.h"
+
+andino::MotorDriver left_motor(andino::Hw::kLeftMotorEnableGpioPin,
+                               andino::Hw::kLeftMotorForwardGpioPin,
+                               andino::Hw::kLeftMotorBackwardGpioPin);
+
+andino::MotorDriver right_motor(andino::Hw::kRightMotorEnableGpioPin,
+                                andino::Hw::kRightMotorForwardGpioPin,
+                                andino::Hw::kRightMotorBackwardGpioPin);
+
+andino::EncoderDriver left_encoder(andino::Hw::kLeftEncoderChannelAGpioPin,
+                                   andino::Hw::kLeftEncoderChannelBGpioPin);
+
+andino::EncoderDriver right_encoder(andino::Hw::kRightEncoderChannelAGpioPin,
+                                    andino::Hw::kRightEncoderChannelBGpioPin);
+
+andino::Pid left_pid_controller(andino::Constants::kPidKp, andino::Constants::kPidKd,
+                                andino::Constants::kPidKi, andino::Constants::kPidKo,
+                                -andino::Constants::kPwmMax, andino::Constants::kPwmMax);
+
+andino::Pid right_pid_controller(andino::Constants::kPidKp, andino::Constants::kPidKd,
+                                 andino::Constants::kPidKi, andino::Constants::kPidKo,
+                                 -andino::Constants::kPwmMax, andino::Constants::kPwmMax);
+
+void IRAM_ATTR read_left_enc();
+void IRAM_ATTR read_right_enc();
+void adjust_motors_speed();
+void set_motor_speed(int left_speed, int right_speed);
+
+rcl_publisher_t right_encoder_publisher;
+rcl_publisher_t left_encoder_publisher;
+rcl_subscription_t motor_speed_subs;
+
+std_msgs__msg__Int64 left_encoder_value;
+std_msgs__msg__Int64 right_encoder_value;
+
+std_msgs__msg__Int64MultiArray incoming_msg_speed;
+
+rclc_executor_t executor;
+rclc_support_t support;
+rcl_allocator_t allocator;
+rcl_node_t node;
+rcl_timer_t timer;
+
+#define RCCHECK(fn)                \
+  {                                \
+    rcl_ret_t temp_rc = fn;        \
+    if ((temp_rc != RCL_RET_OK)) { \
+      error_loop();                \
+    }                              \
+  }
+#define RCSOFTCHECK(fn)            \
+  {                                \
+    rcl_ret_t temp_rc = fn;        \
+    if ((temp_rc != RCL_RET_OK)) { \
+    }                              \
+  }
+
+// Error handle loop
+void error_loop() {
+  while (1) {
+    delay(100);
+  }
+}
+
+void timer_callback(rcl_timer_t* timer, int64_t last_call_time) {
+  RCLC_UNUSED(last_call_time);
+  if (timer != NULL) {
+    adjust_motors_speed();
+    left_encoder_value.data = left_encoder.read();
+    right_encoder_value.data = right_encoder.read();
+
+    RCSOFTCHECK(rcl_publish(&left_encoder_publisher, (const void*)&left_encoder_value, NULL));
+    RCSOFTCHECK(rcl_publish(&right_encoder_publisher, (const void*)&right_encoder_value, NULL));
+  }
+}
+
+void cmd_motor_callback(const void* msgin) {
+  const std_msgs__msg__Int64MultiArray* msg = (const std_msgs__msg__Int64MultiArray*)msgin;
+  set_motor_speed(msg->data.data[0], msg->data.data[1]);
+}
+
+void setup() {
+  // Configure serial transport
+  Serial.begin(57600);
+  set_microros_serial_transports(Serial);
+  delay(2000);
+
+  allocator = rcl_get_default_allocator();
+
+  // create init_options
+  RCCHECK(rclc_support_init(&support, 0, NULL, &allocator));
+
+  // create node
+  RCCHECK(rclc_node_init_default(&node, "micro_ros_platformio_node", "", &support));
+
+  // create publisher
+  RCCHECK(rclc_publisher_init_default(&right_encoder_publisher, &node,
+                                      ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Int64),
+                                      "andino/rigth_position"));
+
+  RCCHECK(rclc_publisher_init_default(&left_encoder_publisher, &node,
+                                      ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Int64),
+                                      "andino/left_position"));
+
+  RCCHECK(rclc_subscription_init_default(
+      &motor_speed_subs, &node, ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Int64MultiArray),
+      "andino/motor_speed"));
+
+  // create timer,
+  const unsigned int timer_timeout = 1000 / andino::Constants::kPidRate;
+  RCCHECK(rclc_timer_init_default(&timer, &support, RCL_MS_TO_NS(timer_timeout), timer_callback));
+
+  incoming_msg_speed.data.capacity = 2;
+  incoming_msg_speed.data.size = 0;
+  incoming_msg_speed.data.data =
+      (int64_t*)malloc(incoming_msg_speed.data.capacity * sizeof(int64_t));
+
+  incoming_msg_speed.layout.dim.capacity = 2;
+  incoming_msg_speed.layout.dim.size = 0;
+  incoming_msg_speed.layout.dim.data = (std_msgs__msg__MultiArrayDimension*)malloc(
+      incoming_msg_speed.layout.dim.capacity * sizeof(std_msgs__msg__MultiArrayDimension));
+
+  for (size_t i = 0; i < incoming_msg_speed.layout.dim.capacity; i++) {
+    incoming_msg_speed.layout.dim.data[i].label.capacity = 2;
+    incoming_msg_speed.layout.dim.data[i].label.size = 0;
+    incoming_msg_speed.layout.dim.data[i].label.data =
+        (char*)malloc(incoming_msg_speed.layout.dim.data[i].label.capacity * sizeof(char));
+  }
+
+  // create executor
+  RCCHECK(rclc_executor_init(&executor, &support.context, 2, &allocator));
+  RCCHECK(rclc_executor_add_timer(&executor, &timer));
+  RCCHECK(rclc_executor_add_subscription(&executor, &motor_speed_subs, &incoming_msg_speed,
+                                         &cmd_motor_callback, ON_NEW_DATA));
+
+  left_encoder_value.data = 0.0;
+  right_encoder_value.data = 0.0;
+
+  left_motor.begin();
+  right_motor.begin();
+
+  left_encoder.begin();
+  right_encoder.begin();
+
+  attachInterrupt(andino::Hw::kLeftEncoderChannelAGpioPin, read_left_enc, CHANGE);
+  attachInterrupt(andino::Hw::kLeftEncoderChannelBGpioPin, read_left_enc, CHANGE);
+  attachInterrupt(andino::Hw::kRightEncoderChannelAGpioPin, read_right_enc, CHANGE);
+  attachInterrupt(andino::Hw::kRightEncoderChannelBGpioPin, read_right_enc, CHANGE);
+
+  left_pid_controller.reset(left_encoder.read());
+  right_pid_controller.reset(right_encoder.read());
+}
+
+void loop() {
+  delay(100);
+  RCSOFTCHECK(rclc_executor_spin_some(&executor, RCL_MS_TO_NS(100)));
+}
+
+void IRAM_ATTR read_left_enc() { left_encoder.callback(); }
+
+void IRAM_ATTR read_right_enc() { right_encoder.callback(); }
+
+void stop_motors() {
+  left_motor.set_speed(0);
+  right_motor.set_speed(0);
+
+  left_pid_controller.disable();
+  right_pid_controller.disable();
+}
+
+void set_motor_speed(int left_speed, int right_speed) {
+  const int left_motor_speed = left_speed;
+  const int right_motor_speed = right_speed;
+
+  if (left_motor_speed == 0 && right_motor_speed == 0) {
+    left_motor.set_speed(0);
+    right_motor.set_speed(0);
+    left_pid_controller.reset(left_encoder.read());
+    right_pid_controller.reset(right_encoder.read());
+    left_pid_controller.disable();
+    right_pid_controller.disable();
+  } else {
+    left_pid_controller.enable();
+    right_pid_controller.enable();
+  }
+
+  left_pid_controller.set_setpoint(left_motor_speed / andino::Constants::kPidRate);
+  right_pid_controller.set_setpoint(right_motor_speed / andino::Constants::kPidRate);
+}
+
+void adjust_motors_speed() {
+  int left_motor_speed = 0;
+  int right_motor_speed = 0;
+
+  left_pid_controller.compute(left_encoder.read(), left_motor_speed);
+  right_pid_controller.compute(right_encoder.read(), right_motor_speed);
+  if (left_pid_controller.enabled()) {
+    left_motor.set_speed(left_motor_speed);
+  }
+
+  if (right_pid_controller.enabled()) {
+    right_motor.set_speed(right_motor_speed);
+  }
+}

--- a/andino_firmware_esp32/src/motor_driver.cpp
+++ b/andino_firmware_esp32/src/motor_driver.cpp
@@ -1,0 +1,66 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2024, Ekumen Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#include "motor_driver.h"
+
+namespace andino {
+MotorDriver::MotorDriver(const int& enable_pwm_out, const int& forward_out, const int& backward_out)
+    : enable_pwm_out_{enable_pwm_out}, forward_out_{forward_out}, backward_out_{backward_out} {}
+
+void MotorDriver::begin() {
+  pinMode(enable_pwm_out_, OUTPUT);
+  pinMode(forward_out_, OUTPUT);
+  pinMode(backward_out_, OUTPUT);
+}
+
+void MotorDriver::set_speed(int speed) {
+  bool forward = true;
+
+  if (speed > kMaxSpeed) {
+    speed = kMaxSpeed;
+  }
+
+  if (speed < kMinSpeed) {
+    speed = -speed;
+    forward = false;
+  }
+
+  if (forward) {
+    digitalWrite(backward_out_, HIGH);
+    digitalWrite(forward_out_, LOW);
+  } else {
+    digitalWrite(backward_out_, LOW);
+    digitalWrite(forward_out_, HIGH);
+  }
+
+  analogWrite(enable_pwm_out_, speed);
+}
+}  // namespace andino

--- a/andino_firmware_esp32/src/motor_driver.h
+++ b/andino_firmware_esp32/src/motor_driver.h
@@ -1,0 +1,74 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2024, Ekumen Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+#include <Arduino.h>
+
+namespace andino {
+
+/// @brief This class allows to control a DC motor by enabling it and setting
+/// its speed. The involved pins are expected to be connected to a full-bridge
+/// motor driver module, such as the L298N.
+class MotorDriver {
+ public:
+  /// @brief Constructs a new MotorDriver object.
+  ///
+  /// @param enable_pwm_out PWM output connected to motor enable pin.
+  /// @param forward_out Output connected to motor forward pin.
+  /// @param backward_out Output connected to motor backward pin.
+  MotorDriver(const int& enable_pwm_out, const int& forward_out, const int& backward_out);
+
+  /// @brief Initializes the motor.
+  void begin();
+
+  /// @brief Sets the motor speed.
+  ///
+  /// @param speed Motor speed value.
+  void set_speed(int speed);
+
+ private:
+  /// Minimum speed value (negative speeds are considered as positive backward
+  /// speeds).
+  static constexpr int kMinSpeed{0};
+
+  /// Maximum speed value.
+  static constexpr int kMaxSpeed{255};
+
+  /// PWM output connected to motor enable pin.
+  int enable_pwm_out_{0};
+
+  /// Digital output connected to motor forward pin.
+  int forward_out_{0};
+
+  /// Digital output connected to motor backward pin.
+  int backward_out_{0};
+};
+}  // namespace andino

--- a/andino_firmware_esp32/src/pid.cpp
+++ b/andino_firmware_esp32/src/pid.cpp
@@ -1,0 +1,89 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2024, Ekumen Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#include "pid.h"
+
+namespace andino {
+void Pid::reset(int encoder_count) {
+  // Since we can assume that the PID is only turned on when going from stop to
+  // moving, we can init
+  // everything on zero.
+  setpoint_ = 0;
+  integral_term_ = 0;
+  last_enconder_count_ = encoder_count;
+  last_input_ = 0;
+  last_output_ = 0;
+}
+
+void Pid::enable() { enabled_ = true; }
+
+bool Pid::enabled() { return enabled_; }
+
+void Pid::disable() { enabled_ = false; }
+
+void Pid::compute(int encoder_count, int& computed_output) {
+  if (!enabled_) {
+    if (last_input_ != 0) {
+      reset(encoder_count);
+    }
+    return;
+  }
+
+  int input = encoder_count - last_enconder_count_;
+  long error = setpoint_ - input;
+
+  long output = (kp_ * error - kd_ * (input - last_input_) + integral_term_) / ko_;
+  output += last_output_;
+
+  if (output >= output_max_) {
+    output = output_max_;
+  } else if (output <= output_min_) {
+    output = output_min_;
+  } else {
+    integral_term_ += ki_ * error;
+  }
+
+  computed_output = output;
+
+  last_enconder_count_ = encoder_count;
+  last_input_ = input;
+  last_output_ = output;
+}
+
+void Pid::set_setpoint(int setpoint) { setpoint_ = setpoint; }
+
+void Pid::set_tunings(int kp, int kd, int ki, int ko) {
+  kp_ = kp;
+  kd_ = kd;
+  ki_ = ki;
+  ko_ = ko;
+}
+}  // namespace andino

--- a/andino_firmware_esp32/src/pid.h
+++ b/andino_firmware_esp32/src/pid.h
@@ -1,0 +1,112 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2024, Ekumen Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+namespace andino {
+
+/// @brief This class provides a simple PID controller implementation.
+class Pid {
+ public:
+  /// @brief Constructs a new PID object.
+  ///
+  /// @param kp Tuning proportional gain.
+  /// @param kd Tuning derivative gain.
+  /// @param ki Tuning integral gain.
+  /// @param ko Tuning output gain.
+  /// @param output_min Output minimum limit.
+  /// @param output_max Output maximum limit.
+  Pid(int kp, int kd, int ki, int ko, int output_min, int output_max)
+      : kp_{kp}, kd_{kd}, ki_{ki}, ko_{ko}, output_min_{output_min}, output_max_{output_max} {}
+
+  /// @brief Resets the PID controller.
+  ///
+  /// @param encoder_count Current encoder value.
+  void reset(int encoder_count);
+
+  /// @brief Enables the PID controller.
+  void enable();
+
+  /// @brief Returns if the PID controller is enabled or not.
+  bool enabled();
+
+  /// @brief Disables the PID controller.
+  void disable();
+
+  /// @brief Computes a new output.
+  ///
+  /// @param encoder_count Current encoder value.
+  /// @param computed_output Computed output value.
+  void compute(int encoder_count, int& computed_output);
+
+  /// @brief Sets the setpoint.
+  ///
+  /// @param setpoint Desired setpoint value.
+  void set_setpoint(int setpoint);
+
+  /// @brief Sets the tuning gains.
+  ///
+  /// @param kp Tuning proportional gain.
+  /// @param kd Tuning derivative gain.
+  /// @param ki Tuning integral gain.
+  /// @param ko Tuning output gain.
+  void set_tunings(int kp, int kd, int ki, int ko);
+
+ private:
+  /// Tuning proportional gain.
+  int kp_{0};
+  /// Tuning derivative gain.
+  int kd_{0};
+  /// Tuning integral gain.
+  int ki_{0};
+  /// Tuning output gain.
+  int ko_{0};
+
+  /// Output minimum limit.
+  int output_min_{0};
+  /// Output maximum limit.
+  int output_max_{0};
+
+  /// True if the PID is enabled, false otherwise.
+  bool enabled_{false};
+
+  /// Setpoint value.
+  int setpoint_{0};
+  /// Accumulated integral term.
+  int integral_term_{0};
+  /// Last received encoder value.
+  long last_enconder_count_{0};
+  /// Last computed input value.
+  int last_input_{0};
+  /// Last computed output value.
+  long last_output_{0};
+};
+}  // namespace andino

--- a/andino_firmware_esp32/tools/formatter.sh
+++ b/andino_firmware_esp32/tools/formatter.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# BSD 3-Clause License
+#
+# Copyright (c) 2023, Ekumen Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+SCRIPT_FILE_PATH=$(realpath ${BASH_SOURCE[0]})
+SCRIPT_DIR_PATH=$(dirname $SCRIPT_FILE_PATH)
+ANDINO_FIRMWARE_DIR_PATH=$SCRIPT_DIR_PATH/..
+
+pushd $ANDINO_FIRMWARE_DIR_PATH
+clang-format -style=file -i -fallback-style=none src/*.cpp src/*.h
+popd


### PR DESCRIPTION
## What is included

- This includes the firmware to use the andino with esp32.
- The src/main.cpp has the code to use the andino with micro-ros.
- In the platformio.init, have the configuration for:
      -  micro-ros dependencies
      -  serial communication, by using micro-ros
      - ros distribution, in this case is humble (but we can change to Jazzy)

